### PR TITLE
Fix typo in Grave Touch attack ability

### DIFF
--- a/packs/_source/spells/cantrip/grave-touch.7fzSBJVQNGnnLe7s.json
+++ b/packs/_source/spells/cantrip/grave-touch.7fzSBJVQNGnnLe7s.json
@@ -35,7 +35,7 @@
               }
             ]
           },
-          "ability": "none",
+          "ability": "",
           "attack": {
             "flat": false,
             "bonus": ""


### PR DESCRIPTION
Change Grave Touch attack ability from "none" to "" which should display as default in UI.

This should resolve #1099 