### PR TITLE
[#1110] Update weapon quantities when thrown

### DIFF
--- a/code/documents/activity/attack-activity.mjs
+++ b/code/documents/activity/attack-activity.mjs
@@ -81,7 +81,7 @@ export default class AttackActivity extends Activity {
 
 	/** @inheritDoc */
 	get modifierData() {
-		// Identify if a specific attack is a thrown weapon. 
+		// Identify if a specific attack is a thrown weapon.
 		// By default, most attacks have the correct type throughout, but a thrown weapon moves from "melee" to "ranged" at the time of the attack
 		const defaultAttackMode = this.item.system.attackModes[0]?.value;
 		const defaultAttackType =
@@ -156,6 +156,12 @@ export default class AttackActivity extends Activity {
 	 * @property {string} id        ID of the ammunition item to update.
 	 * @property {boolean} destroy  Will the ammunition item be deleted?
 	 * @property {number} quantity  New quantity after the ammunition is spent.
+	 */
+
+	/**
+	 * @typedef {object} WeaponUpdate
+	 * @property {string} id        ID of the weapon item to update.
+	 * @property {number} quantity  New quantity after the weapon is thrown.
 	 */
 
 	/**
@@ -306,6 +312,15 @@ export default class AttackActivity extends Activity {
 			ammoUpdate = { id: ammo.id, quantity: Math.max(0, ammo.system.quantity - 1) };
 			flags.ammunition = ammo.id;
 		}
+
+		const weapon = this.item;
+		const isThrown =
+			weapon.system.properties?.has("thrown") && ["thrown", "thrownOffhand"].includes(rollConfig.attackMode);
+		let weaponUpdate = null;
+		if (isThrown && (weapon.system.quantity ?? 0) > 0) {
+			weaponUpdate = { id: weapon.id, quantity: Math.max(0, (weapon.system.quantity ?? 0) - 1) };
+		}
+
 		if (rollConfig.attackMode) flags.attackMode = rollConfig.attackMode;
 		if (!foundry.utils.isEmpty(flags) && this.actor.items.has(this.item.id)) {
 			await this.item.setFlag(game.system.id, flagKey, flags);
@@ -318,14 +333,19 @@ export default class AttackActivity extends Activity {
 		 * @param {ChallengeRoll[]} rolls - The resulting rolls.
 		 * @param {object} [data]
 		 * @param {AmmunitionUpdate|null} [data.ammoUpdate] - Any updates related to ammo consumption for the attack.
+		 * @param {object} [data.weaponUpdate] - Any updates related to weapon quantity for thrown weapons.
 		 * @param {Activity} [data.subject] - Activity for which the roll was performed.
 		 */
-		Hooks.callAll("blackFlag.rollAttack", rolls, { ammoUpdate, subject: this });
+		Hooks.callAll("blackFlag.rollAttack", rolls, { ammoUpdate, weaponUpdate, subject: this });
 
 		if (ammoUpdate)
 			await this.actor?.updateEmbeddedDocuments("Item", [
 				{ _id: ammoUpdate.id, "system.quantity": ammoUpdate.quantity }
-			]);
+		]);
+		if (weaponUpdate)
+			await this.actor?.updateEmbeddedDocuments("Item", [
+				{ _id: weaponUpdate.id, "system.quantity": weaponUpdate.quantity }
+		]);
 
 		/**
 		 * A hook event that fires after an attack has been rolled.

--- a/code/documents/activity/attack-activity.mjs
+++ b/code/documents/activity/attack-activity.mjs
@@ -81,22 +81,11 @@ export default class AttackActivity extends Activity {
 
 	/** @inheritDoc */
 	get modifierData() {
-		// Identify if a specific attack is a thrown weapon.
-		// By default, most attacks have the correct type throughout, but a thrown weapon moves from "melee" to "ranged" at the time of the attack
-		const defaultAttackMode = this.item.system.attackModes[0]?.value;
-		const defaultAttackType =
-			defaultAttackMode === "thrown" || defaultAttackMode === "thrownOffhand" ? "ranged" : this.item.system.type.value;
-
 		return {
 			type: "attack",
 			kind: "attack",
 			ability: this.ability,
-			...foundry.utils.mergeObject(super.modifierData, {
-				activity: {
-					type: { value: defaultAttackType },
-					...this.system
-				}
-			})
+			...super.modifierData
 		};
 	}
 
@@ -537,7 +526,9 @@ export default class AttackActivity extends Activity {
 		modifierData = foundry.utils.mergeObject(modifierData, {
 			activity: {
 				...this.system,
-				type: { value: attackType }
+				attack: {
+					type: { value: attackType }
+				}
 			}
 		});
 

--- a/code/documents/activity/attack-activity.mjs
+++ b/code/documents/activity/attack-activity.mjs
@@ -81,11 +81,22 @@ export default class AttackActivity extends Activity {
 
 	/** @inheritDoc */
 	get modifierData() {
+		// Identify if a specific attack is a thrown weapon. 
+		// By default, most attacks have the correct type throughout, but a thrown weapon moves from "melee" to "ranged" at the time of the attack
+		const defaultAttackMode = this.item.system.attackModes[0]?.value;
+		const defaultAttackType =
+			defaultAttackMode === "thrown" || defaultAttackMode === "thrownOffhand" ? "ranged" : this.item.system.type.value;
+
 		return {
 			type: "attack",
 			kind: "attack",
 			ability: this.ability,
-			...super.modifierData
+			...foundry.utils.mergeObject(super.modifierData, {
+				activity: {
+					type: { value: defaultAttackType },
+					...this.system
+				}
+			})
 		};
 	}
 
@@ -497,6 +508,18 @@ export default class AttackActivity extends Activity {
 		if (this.item.system.properties?.has("versatile") && rollConfig.attackMode === "twoHanded") {
 			damage = this.item.system.versatileDamage ?? damage;
 		}
+
+		// Compute the correct attack type based on attackMode for thrown weapons
+		const attackMode = rollConfig.attackMode ?? this.item.system.attackModes[0]?.value;
+		const attackType =
+			attackMode === "thrown" || attackMode === "thrownOffhand" ? "ranged" : this.item.system.type.value;
+
+		modifierData = foundry.utils.mergeObject(modifierData, {
+			activity: {
+				...this.system,
+				type: { value: attackType }
+			}
+		});
 
 		const roll = super._processDamagePart(damage, rollConfig, rollData, {
 			...config,


### PR DESCRIPTION
Solutions for issue #1110 

This does two things:
1. Updates the quantity on a thrown weapon in a fashion similar to how ammo quantity is currently updated.
2. Updates the `_processDamagePart` to incorporate the incoming Attack Type under `activity.attack.type.value`.

## How this was tested

Using a fixed Barbarian rage (see #1091), I rolled attacks and damage both as Thrown and Melee.
- The Melee damage included the Rage Bonus
- The Thrown damage did not include the Rage Bonus and it decremented the quantity

I've include a few screenshots below.

Initial state: Barbarian is Raging they have three handaxes
<img width="937" height="473" alt="image" src="https://github.com/user-attachments/assets/7af0c632-8379-4879-a649-c60ad5856b9c" />

Barbarian attacks with a Thrown Handaxe and the quantity decrements
<img width="1607" height="419" alt="image" src="https://github.com/user-attachments/assets/ebe803dd-1987-4e9a-97cc-8cf909aa9aaf" />

Barbarian rolls damage and the Rage bonus is missing (as expected)
<img width="296" height="270" alt="image" src="https://github.com/user-attachments/assets/b3c8e3ef-fcb7-494e-8aa8-319ad63f885b" />

Doing the same thing again, but this time with a Melee version. Note the Rage bonus is now included in the damage.
<img width="296" height="685" alt="image" src="https://github.com/user-attachments/assets/1df2d700-1ea4-4383-acbb-cd70c06586d2" />


