### PR TITLE
[#1091] Updates active effects that leverage activity.attack.type.value

### DIFF
--- a/packs/_source/classes/barbarian/features/brutal-critical.0RNSFvVul05sNBj7.json
+++ b/packs/_source/classes/barbarian/features/brutal-critical.0RNSFvVul05sNBj7.json
@@ -49,12 +49,12 @@
             {
               "key": "system.modifiers",
               "mode": 2,
-              "value": "{ \"type\": \"critical-threshold\", \"filter\": [{ \"k\": \"activity.type.value\", \"v\": \"melee\" }, { \"k\": \"activity.type.classification\", \"v\": \"weapon\" }], \"formula\": \"19\" }"
+              "value": "{ \"type\": \"critical-threshold\", \"filter\": [{ \"k\": \"activity.attack.type.value\", \"v\": \"melee\" }, { \"k\": \"activity.type.classification\", \"v\": \"weapon\" }], \"formula\": \"19\" }"
             },
             {
               "key": "system.modifiers",
               "mode": 2,
-              "value": "{ \"type\": \"critical-dice\", \"filter\": [{ \"k\": \"activity.type.value\", \"v\": \"melee\" }], \"formula\": \"@scale.barbarian.dice\" }"
+              "value": "{ \"type\": \"critical-dice\", \"filter\": [{ \"k\": \"activity.attack.type.value\", \"v\": \"melee\" }], \"formula\": \"@scale.barbarian.dice\" }"
             }
           ]
         },

--- a/packs/_source/classes/barbarian/features/rage.7wqTqzh8CYPFXqSW.json
+++ b/packs/_source/classes/barbarian/features/rage.7wqTqzh8CYPFXqSW.json
@@ -131,7 +131,7 @@
         {
           "key": "system.modifiers",
           "mode": 2,
-          "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"damage\" }, { \"k\": \"kind\", \"v\": \"attack\" }, { \"k\": \"ability\", \"v\": \"strength\" }, { \"k\": \"activity.type.value\", \"v\": \"melee\" }], \"formula\": \"@scale.barbarian.damage\" }",
+          "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"damage\" }, { \"k\": \"kind\", \"v\": \"attack\" }, { \"k\": \"ability\", \"v\": \"strength\" }, { \"k\": \"activity.attack.type.value\", \"v\": \"melee\" }], \"formula\": \"@scale.barbarian.damage\" }",
           "priority": null
         },
         {

--- a/packs/_source/classes/druid/subclasses/shifter-features/fire.Qco8rSb1pldTRusr.json
+++ b/packs/_source/classes/druid/subclasses/shifter-features/fire.Qco8rSb1pldTRusr.json
@@ -56,7 +56,7 @@
         {
           "key": "system.modifiers",
           "mode": 2,
-          "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"damage\" }, { \"k\": \"activity.type.value\", \"v\": \"melee\" }], \"formula\": \"1d8[fire]\" }",
+          "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"damage\" }, { \"k\": \"activity.attack.type.value\", \"v\": \"melee\" }], \"formula\": \"1d8[fire]\" }",
           "priority": null
         }
       ],

--- a/packs/_source/classes/rogue/features/precise-critical.69hPo8w9MtCBkcwU.json
+++ b/packs/_source/classes/rogue/features/precise-critical.69hPo8w9MtCBkcwU.json
@@ -45,12 +45,12 @@
             {
               "key": "system.modifiers",
               "mode": 2,
-              "value": "{ \"type\": \"critical-threshold\", \"filter\": [{ \"o\": \"OR\", \"v\": [{ \"k\": \"activity.type.value\", \"v\": \"ranged\" }, { \"k\": \"item.properties\", \"o\": \"has\", \"v\": \"finesse\" }] }, { \"k\": \"activity.type.classification\", \"v\": \"weapon\" }], \"formula\": \"19\" }"
+              "value": "{ \"type\": \"critical-threshold\", \"filter\": [{ \"o\": \"OR\", \"v\": [{ \"k\": \"activity.attack.type.value\", \"v\": \"ranged\" }, { \"k\": \"item.properties\", \"o\": \"has\", \"v\": \"finesse\" }] }, { \"k\": \"activity.type.classification\", \"v\": \"weapon\" }], \"formula\": \"19\" }"
             },
             {
               "key": "system.modifiers",
               "mode": 2,
-              "value": "{ \"type\": \"critical-dice\", \"filter\": [{ \"o\": \"OR\", \"v\": [{ \"k\": \"activity.type.value\", \"v\": \"ranged\" }, { \"k\": \"item.properties\", \"o\": \"has\", \"v\": \"finesse\" }] }, { \"k\": \"activity.type.classification\", \"v\": \"weapon\" }], \"formula\": \"@scale.rogue.critical\" }"
+              "value": "{ \"type\": \"critical-dice\", \"filter\": [{ \"o\": \"OR\", \"v\": [{ \"k\": \"activity.attack.type.value\", \"v\": \"ranged\" }, { \"k\": \"item.properties\", \"o\": \"has\", \"v\": \"finesse\" }] }, { \"k\": \"activity.type.classification\", \"v\": \"weapon\" }], \"formula\": \"@scale.rogue.critical\" }"
             }
           ]
         },


### PR DESCRIPTION
Proposed fix for #1091 

Found the correct value just by inspection of the data. These were the only abilities in the core Black Flag material that seem to be impacted by this change. There may be more in the core books, but I will leave that to the maintainer to coordinate.

I tested this feature with the Barbarian Rage and it correctly picked up the extra damage for attacks.

(Note that thrown weapons are not correctly excluded, that is fixed in a separate issue PR)