### PR TITLE
[#1086] Fix typo on Manifest Miracles advancement name

### DIFF
--- a/packs/_source/classes/cleric/features/manifest-miracles.innskwMl6jteEy4R.json
+++ b/packs/_source/classes/cleric/features/manifest-miracles.innskwMl6jteEy4R.json
@@ -32,7 +32,7 @@
           "classIdentifier": ""
         },
         "flags": {},
-        "title": "Manifest Mircales Cantrip",
+        "title": "Manifest Miracles Cantrip",
         "icon": "",
         "hint": "You learn one additional cantrip of your choice from any source of magic. This cantrip counts as a Divine cantrip for you, but it doesn’t count against the number of cantrips you know."
       }


### PR DESCRIPTION
Fix for #1086 