### PR TITLE
Armor Expert now has effects

### DIFF
--- a/packs/_source/talents/martial-talents/armor-expert.jtNiyOYW61nRvU12.json
+++ b/packs/_source/talents/martial-talents/armor-expert.jtNiyOYW61nRvU12.json
@@ -18,7 +18,7 @@
       {
         "key": "system.modifiers",
         "mode": 2,
-        "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"armor-class\" }, { \"k\": \"armored\", \"v\": true }, { \"k\": \"armor.type.category\", \"o\" : \"in\", \"v\" : [\"heavy\", \"medium\"]}], \"formula\": \"1\" }",
+        "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"armor-class\" }, { \"k\": \"armored\", \"v\": true }, { \"k\": \"armor.type.category\", \"o\" : \"in\", \"v\" : [\"heavy\", \"medium\"]},{\"k\": \"armor.proficient\", \"v\": true}], \"formula\": \"1\" }",
         "priority": null
       },
       {

--- a/packs/_source/talents/martial-talents/armor-expert.jtNiyOYW61nRvU12.json
+++ b/packs/_source/talents/martial-talents/armor-expert.jtNiyOYW61nRvU12.json
@@ -14,6 +14,20 @@
       "max": ""
     },
     "advancement": {},
+    "changes": [
+      {
+        "key": "system.modifiers",
+        "mode": 2,
+        "value": "{ \"type\": \"bonus\", \"filter\": [{ \"k\": \"type\", \"v\": \"armor-class\" }, { \"k\": \"armored\", \"v\": true }, { \"k\": \"armor.type.category\", \"o\" : \"in\", \"v\" : [\"heavy\", \"medium\"]}], \"formula\": \"1\" }",
+        "priority": null
+      },
+      {
+        "key": "system.modifiers",
+        "mode": 2,
+        "value": "{ \"type\": \"note\", \"filter\": [{ \"k\": \"type\", \"v\": \"ability-save\" }], \"note\": { \"rollMode\": 1, \"text\": \"You have advantage on saves to avoid being pulled, shoved, or knocked prone.\" } }",
+        "priority": null
+      }
+    ],
     "description": {
       "value": "<p>Your experience with armor allows you to weather mighty onslaughts. While you are wearing medium or heavy armor with which you are proficient, you gain these benefits:</p><ul><li><p>Your AC increases by 1.</p></li><li><p>You have advantage on saves to avoid being pulled, shoved, or knocked prone.</p></li></ul>",
       "source": {}


### PR DESCRIPTION
Proposed fix for #945 .

It does not account for the "proficient" aspect, because the data isn't there when we evaluate the filters. `ac-template.mjs` has no reference to the proficiency against a shield or armor, likely because it isn't required outside of weird cases like thing.

However, I don't know that it's terribly meaningful as most people won't even have this trait if they're wearing non-proficient armor. I think that having at least these filters is better than having none.