### PR TITLE
Fix AoE size/width/height/unit not persisting on spell items

### DIFF
--- a/templates/shared/parts/activity-template.hbs
+++ b/templates/shared/parts/activity-template.hbs
@@ -11,24 +11,24 @@
 	{{/blackFlag-formGroup}}
 	{{#with target.aoeSizes as |aoeSizes|}}
 		{{#blackFlag-formGroup "BF.TARGET.FIELDS.target.template.size.label"}}
-			{{ formField ../fields.target.fields.template.fields.size name=(concat prefix "target.template.size")
+			{{ formField ../fields.target.fields.template.fields.size name=(concat ../prefix "target.template.size")
 			             value=../data.target.template.size classes="label-top" label=(localize aoeSizes.size)
-			             hint="" rootId=partId }}
+			             hint="" rootId=../partId }}
 			{{#if aoeSizes.width}}
 				<i class="fa-solid fa-times separator" inert></i>
-				{{ formField ../fields.target.fields.template.fields.width name=(concat prefix "target.template.width")
+				{{ formField ../fields.target.fields.template.fields.width name=(concat ../prefix "target.template.width")
 				             value=../data.target.template.width classes="label-top" label=(localize aoeSizes.width)
-				             hint="" rootId=partId }}
+				             hint="" rootId=../partId }}
 			{{/if}}
 			{{#if aoeSizes.height}}
 				<i class="fa-solid fa-times separator" inert></i>
-				{{ formField ../fields.target.fields.template.fields.height name=(concat prefix "target.template.height")
+				{{ formField ../fields.target.fields.template.fields.height name=(concat ../prefix "target.template.height")
 				             value=../data.target.template.height classes="label-top" label=(localize aoeSizes.height)
-				             hint="" rootId=partId }}
+				             hint="" rootId=../partId }}
 			{{/if}}
-			{{ formField ../fields.target.fields.template.fields.unit name=(concat prefix "target.template.unit")
+			{{ formField ../fields.target.fields.template.fields.unit name=(concat ../prefix "target.template.unit")
 									 value=../data.target.template.unit options=../CONFIG.distanceUnits.localizedOptions
-									 classes="label-top" hint="" rootId=partId }}
+									 classes="label-top" hint="" rootId=../partId }}
 		{{/blackFlag-formGroup}}
 	{{/with}}
 	{{#if (and data.target.template.type data.target.template.count)}}


### PR DESCRIPTION
### Problem
On spell item sheets, setting Area of Effect size, width, height, or unit values would not persist. The values disappeared when switching tabs or toggling the sheet lock. The AoE *type* (Sphere, Cone, etc.) saved correctly.

### Root Cause
In `templates/shared/parts/activity-template.hbs`, the size/width/height/unit form fields are rendered inside a `{{#with target.aoeSizes as |aoeSizes|}}` block (lines 12–33). Handlebars `#with` changes the current context, so variables from the outer scope require `../` to resolve correctly.

The template already used `../` for `fields` and `data` inside this block, but `prefix` and `partId` were missing it. As a result, `prefix` resolved against the `aoeSizes` object (where it doesn't exist) instead of the partial's parent context, producing `undefined`. The `concat` helper then generated form field names like `target.template.size` instead of `system.target.template.size`, so the submitted values never reached the document's schema path and were silently ignored.

The AoE *type* dropdown was unaffected because it sits outside the `#with` block where `prefix` resolves correctly.

### Fix

In `templates/shared/parts/activity-template.hbs`, added `../` to 8 references inside the `{{#with target.aoeSizes}}` block:

- `prefix` → `../prefix` (4 occurrences — size, width, height, unit field names)
- `partId` → `../partId` (4 occurrences — corresponding rootId attributes)

This fix was successfully tested on my local. No JavaScript changes are required. 