### PR TITLE
[#1104] Add item scaling to messageFlags and fix updates

### DIFF
--- a/code/documents/activity/activity.mjs
+++ b/code/documents/activity/activity.mjs
@@ -296,11 +296,16 @@ export default class Activity extends PseudoDocumentMixin(BaseActivity) {
 	 * @type {object}
 	 */
 	get messageFlags() {
-		return {
+		const flags = {
 			activity: { type: this.type, id: this.id, uuid: this.uuid },
 			item: { type: this.item.type, id: this.item.id, uuid: this.item.uuid },
 			targets: getTargetDescriptors()
 		};
+
+		const scaling = Number(this.item.getFlag(game.system.id, "scaling")) || 0;
+		if (scaling > 0) flags.scaling = scaling;
+
+		return flags;
 	}
 
 	/* <><><><> <><><><> <><><><> <><><><> */
@@ -1255,7 +1260,7 @@ export default class Activity extends PseudoDocumentMixin(BaseActivity) {
 			const updates = {};
 			if (consumed) updates["flags.dnd5e.consumed"] = consumed;
 			if (scaling) {
-				const updates = { [`flags.${game.system.id}.scaling`]: scaling };
+				updates[`flags.${game.system.id}.scaling`] = scaling;
 				if (item.type === "spell") {
 					updates["system.circle.value"] = (item.system.circle.value ?? item.system.circle.base) + scaling;
 				}

--- a/code/documents/activity/activity.mjs
+++ b/code/documents/activity/activity.mjs
@@ -302,8 +302,8 @@ export default class Activity extends PseudoDocumentMixin(BaseActivity) {
 			targets: getTargetDescriptors()
 		};
 
-		const scaling = Number(this.item.getFlag(game.system.id, "scaling")) || 0;
-		if (scaling > 0) flags.scaling = scaling;
+		const scaling = Number(this.item.getFlag(game.system.id, "scaling"));
+		if (Number.isNumeric(scaling) && scaling > 0) flags.scaling = scaling;
 
 		return flags;
 	}


### PR DESCRIPTION
This enhancement fixes a handoff problem. The system calculated the spell’s higher-circle scaling correctly, but forgot to pass that scaling along to the chat card damage button. Now the damage button remembers the spell was upcast and rolls the correct extra dice.

The fix writes the scaling data to the existing clone update object instead:

```js
updates[`flags.${game.system.id}.scaling`] = scaling;
```

For spell items, the cloned item also receives the adjusted cast circle:

```js
updates["system.circle.value"] = (item.system.circle.value ?? item.system.circle.base) + scaling;
```

This enhancement also carries positive scaling values forward through `messageFlags`, so attack roll cards and their damage buttons retain the original scaling context.

Impact is limited: only positive scaling values are preserved, only spell items receive an adjusted circle value, and non-scaling activities are unaffected. This allows scalable spell attack damage, such as `6d6 + 1d6 per circle above 4th`, to roll correctly from chat card damage buttons.

A new `black-flag.mjs` was compiled on my local and successfully tested.