### PR TITLE
Add class, subclass, lineage, heritage, background information to PC features tab

### DIFF
--- a/code/config/inventory.mjs
+++ b/code/config/inventory.mjs
@@ -195,6 +195,14 @@ export const sheetSections = {
 			options: { autoHide: true }
 		},
 		{
+			id: "background",
+			tab: "features",
+			label: "BF.Item.Type.Background[one]",
+			filters: [
+				{ k: "type", v: "background" }
+			]
+		},
+		{
 			id: "class-features",
 			tab: "features",
 			label: "BF.Feature.Category.Class[other]",

--- a/code/config/inventory.mjs
+++ b/code/config/inventory.mjs
@@ -229,7 +229,8 @@ export const sheetSections = {
 										v: filters
 									}
 								],
-								levels: cls.levels
+								levels: cls.levels,
+								sublabel: cls.subclass ? `Level ${cls.levels} - ${cls.subclass.identifier}` : `Level ${cls.levels}`
 							},
 							{ inplace: false }
 						);
@@ -250,7 +251,23 @@ export const sheetSections = {
 			filters: [
 				{ k: "type", v: "feature" },
 				{ k: "system.type.category", v: "lineage" }
-			]
+			],
+			expand: (document, sectionData) => {
+				// This function add the selected name of the lineage as a sublabel that can be displayed
+				if (document.system.progression.lineage.name !== "") {
+					return [
+						foundry.utils.mergeObject(
+							sectionData,
+							{
+								sublabel: document.system.progression.lineage.name
+							}
+						)
+					]
+				}
+				else {
+					return [sectionData];
+				}
+			}
 		},
 		{
 			id: "heritage-features",
@@ -259,7 +276,23 @@ export const sheetSections = {
 			filters: [
 				{ k: "type", v: "feature" },
 				{ k: "system.type.category", v: "heritage" }
-			]
+			],
+			expand: (document, sectionData) => {
+				// This function add the selected name of the heritage as a sublabel that can be displayed
+				if (document.system.progression.heritage.name !== "") {
+					return [
+						foundry.utils.mergeObject(
+							sectionData,
+							{
+								sublabel: document.system.progression.heritage.name
+							}
+						)
+					]
+				}
+				else {
+					return [sectionData];
+				}
+			}
 		},
 		{
 			id: "features",

--- a/templates/actor/tabs/pc-features.hbs
+++ b/templates/actor/tabs/pc-features.hbs
@@ -7,7 +7,7 @@
 			{{#each sections.features as |section sectionId|}}
 				<tbody data-section="{{sectionId}}">
 					<tr class="table-header">
-						<td class="name">{{ localize section.label }}</td>
+						<td class="name">{{ localize section.label }} {{#if section.sublabel}}({{section.sublabel}}){{/if}}</td>
 						<th class="uses">{{ localize "BF.Uses.Short" }}</th>
 						<td class="controls"></td>
 					</tr>


### PR DESCRIPTION
A solution for #981 

No data changes here, just a simple display fix.

Note that we're adding the background alongside the features even if they typically won't have clickable actions. I'm doing this because there isn't another location to view these things and you *should* be able to view the data without having to click on "Progressions".